### PR TITLE
Update to MySQL .pkg file name

### DIFF
--- a/mmvMySQL/mmvmysql.sh
+++ b/mmvMySQL/mmvmysql.sh
@@ -5,6 +5,7 @@
 # MACMINIVAULT.COM - @MACMINIVAULT          #
 # VERSION 2.3 RELEASE DATE SEPT 7 2016      #
 # DESC:  THIS SCRIPT INSTALLS MySQL on OSX  #
+# and macOS                                 #
 #############################################
 #REQUIREMENTS:
 #  OS X 10.7 or newer
@@ -51,11 +52,11 @@ curl -# -Lo ~/Downloads/MySQL.dmg http://dev.mysql.com/get/Downloads/MySQL-5.6/m
 hdiutil attach -quiet ~/Downloads/MySQL.dmg
 # PLIST TO ALTER MySQL INSTALLER TO NOT ATTEMPT TO INSTALL STARTUP ITEMS
 curl -s -o ~/Downloads/MySQL-install.plist https://raw.githubusercontent.com/MacMiniVault/Mac-Scripts/master/mmvMySQL/install.plist
-cd /Volumes/mysql-5.6.35-osx10.12-x86_64/
+cd /Volumes/mysql-5.6.35-macos10.12-x86_64/
 echo "..."
 echo "..."
 echo "Installing MySQL, administrator password required ..."
-sudo installer -applyChoiceChangesXML ~/Downloads/MySQL-install.plist -pkg mysql-5.6.35-osx10.12-x86_64.pkg -target /
+sudo installer -applyChoiceChangesXML ~/Downloads/MySQL-install.plist -pkg mysql-5.6.35-macos10.12-x86_64.pkg -target /
 # MySQL START SCRIPT CHANGES PATH - LINKING PIDOF TO THE MySQL DIR
 sudo ln -s /usr/local/bin/pidof /usr/local/mysql/bin/pidof
 echo "..."
@@ -89,7 +90,7 @@ echo "..."
 echo "..."
 # UNMOUNT AND DELELTE DOWNLOADED MySQL INSTALLER
 cd ~/
-hdiutil detach -quiet /Volumes/mysql-5.6.35-osx10.12-x86_64/
+hdiutil detach -quiet /Volumes/mysql-5.6.35-macos10.12-x86_64/
 sleep 2
 rm ~/Downloads/MySQL.dmg
 rm ~/Downloads/MySQL-install.plist


### PR DESCRIPTION
MySQL package name is now adopting the new "macOS" syntax instead of "OSX"